### PR TITLE
Introduced compatibility for PHP 7.2+ and Laravel 7+ Schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.1",
         "digitalcloud/laravel-blameable": "*"
     },
     "autoload": {

--- a/database/migrations/create_notes_table.php.stub
+++ b/database/migrations/create_notes_table.php.stub
@@ -9,10 +9,12 @@ class CreateNotesTable extends Migration
     public function up()
     {
         Schema::create('notes', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
+
             $table->text('note')->nullable();
             $table->morphs('model');
             $table->blameable();
+
             $table->timestamps();
         });
     }

--- a/src/HasNotes.php
+++ b/src/HasNotes.php
@@ -14,9 +14,7 @@ trait HasNotes
 
     public function setNote(string $note): self
     {
-
-        $newNote = $this->notes()->create(['note' => $note]);
-
+        $this->notes()->create(['note' => $note]);
         return $this;
     }
 


### PR DESCRIPTION
Flexed platform requirement to allow for PHP 7+, updated redundant variable assignment and updated Notes table migration to conform with Laravel 7+, specifically `bigIncrements` 